### PR TITLE
Update pipeline to rewrite articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ New Zealand.  The repository contains two parts:
    uv run livingwp
    ```
 
+Running the command above now iterates over each markdown file in
+`src/website/whitepaper/content`, rewriting it with the latest research using
+the agent pipeline.
+
 ## Working on the Website
 
 1. Change to the site directory:

--- a/src/livingwp/__init__.py
+++ b/src/livingwp/__init__.py
@@ -1,6 +1,6 @@
 import asyncio
-from livingwp.agents import run_agent
+from livingwp.agents import update_articles
 
 
 def main() -> None:
-    asyncio.run(run_agent())
+    asyncio.run(update_articles())

--- a/src/livingwp/agents.py
+++ b/src/livingwp/agents.py
@@ -1,4 +1,6 @@
 from agents import Agent, Runner, WebSearchTool
+from pathlib import Path
+from typing import Dict, Tuple
 
 from livingwp.utils.files import load_instruction
 
@@ -30,7 +32,40 @@ planning_agent = Agent(
 )
 
 
+def _parse_markdown(text: str) -> Tuple[Dict[str, str], str, str]:
+    """Parse a markdown file with YAML front matter.
+
+    Returns a tuple of (front_matter_dict, front_matter_text, body).
+    """
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) >= 3:
+            fm_text = parts[1].strip()
+            body = parts[2].lstrip("\n")
+            front_matter: Dict[str, str] = {}
+            for line in fm_text.splitlines():
+                if ":" in line:
+                    key, val = line.split(":", 1)
+                    front_matter[key.strip()] = val.strip()
+            return front_matter, fm_text, body
+    return {}, "", text
+
+
+async def update_articles() -> None:
+    """Run the agent pipeline for each industry article."""
+    content_dir = Path(__file__).resolve().parent.parent / "website" / "whitepaper" / "content"
+    for path in sorted(content_dir.glob("*.markdown")):
+        text = path.read_text()
+        front_matter, fm_text, body = _parse_markdown(text)
+        topic = front_matter.get("title", path.stem.replace("-", " "))
+        initial_input = f"Topic: {topic}\nPrevious article:\n{body}"
+        result = await Runner.run(planning_agent, input=initial_input)
+        updated = f"---\n{fm_text}\n---\n\n{result.final_output.strip()}\n"
+        path.write_text(updated)
+
+
 async def run_agent() -> None:
+    """Legacy entry point for running a single topic."""
     topic = "AI in Education"
     initial_input = f"Topic: {topic}"
     result = await Runner.run(planning_agent, input=initial_input)


### PR DESCRIPTION
## Summary
- add a new `update_articles` pipeline to run through all articles under `src/website/whitepaper/content`
- use the new function in the CLI entry point
- document updated behaviour in the README

## Testing
- `ruff check .`
- `python -m py_compile src/livingwp/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685880f1e8f88328b8fe1c3c2601d08e