### PR TITLE
feat(website): Update copy

### DIFF
--- a/src/website/_config.yml
+++ b/src/website/_config.yml
@@ -18,11 +18,10 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-title: Generative AI Working Group
+title: AI in NZ Living Whitepaper
 email: info@aiforum.org.nz
 description: >-
-  A living snapshot of the Generative AI landscape in Aotearoa New Zealand.
-  Content is automatically updated by LLM agents scanning for the latest news.
+  A living snapshot of the Generative AI landscape in Aotearoa New Zealand. Researching AI topics, using AI, for the AI community.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
@@ -34,6 +33,7 @@ plugins:
 header_pages:
   - whitepaper/index.markdown
   - how-it-works.markdown
+  - about.markdown
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/src/website/about.markdown
+++ b/src/website/about.markdown
@@ -4,6 +4,6 @@ title: About
 permalink: /about/
 ---
 
-AI Forum New Zealand formed the Generative AI Working Group to explore and share developments in this fast-moving field. This site is part of that initiative and serves as a living record of how generative AI is being applied across industries in Aotearoa.
+The Generative AI Working Group was formed under the AI Forum New Zealand to explore and share developments in this fast-moving field. This site is part of that initiative and serves as a living record of how generative AI is being applied across industries in Aotearoa.
 
 Pages for each industry are generated automatically by an LLM agent. As the agent finds new information, the content here will grow. If you would like to contribute or see how the system works, visit the [GitHub repository](https://github.com/mingnz/livingwp).

--- a/src/website/index.markdown
+++ b/src/website/index.markdown
@@ -5,14 +5,13 @@
 layout: home
 ---
 
-Welcome to AI Forum New Zealand's Generative AI Working Group.
+Discover how generative AI is shaping industries across Aotearoa. This website is a living resource, automatically updated by an autonomous agent that scans the web for the latest insights and sector trends.
 
-Discover how generative AI is shaping industries across Aotearoa. This website evolves in real-time, powered by an autonomous agent that scans the web for the latest insights and updates.
+**Explore the Living Whitepaper:**
 
-Dive into the [Living Whitepaper](whitepaper) for sector-specific updates and trends.
+- [Education](whitepaper/education/)
+- [Healthcare](whitepaper/healthcare/)
 
 Curious about the process? [Learn how it works](how-it-works)
 
 Your contributions are invaluable—join us on [GitHub](https://github.com/mingnz/livingwp) and help shape the future of AI in New Zealand.
-
-Researching AI topics, using AI, for the AI community. Developed with the help of AI.

--- a/src/website/whitepaper/index.markdown
+++ b/src/website/whitepaper/index.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Living Whitepaper
+title: Articles
 permalink: /whitepaper/
 ---
 


### PR DESCRIPTION
Makes the website more focused on the Living Whitepaper than the GenAI Working Group (since that'll be on the AI forum website anyway)