### PR TITLE
feat: SEO structured data + GEO (llms.txt, full corpus, per-report markdown)

### DIFF
--- a/src/agent/src/files.ts
+++ b/src/agent/src/files.ts
@@ -189,6 +189,13 @@ export function normalizeArticleMetadata(
 }
 
 /** Extract a plain-text description from the first paragraph of markdown. */
+// Lead lines that are metadata, not prose (date stamps, "snapshot date:",
+// "updated from the … edition", etc.). The extracted description feeds the
+// page meta description, OG/Twitter cards, JSON-LD, and llms.txt, so picking
+// one of these as the summary hurts both SEO and GEO.
+const METADATA_LEAD =
+  /^(updated\b|last updated\b|snapshot date\b|snapshot:|published\b|publication date\b)/i;
+
 export function extractDescription(body: string, maxLength = 160): string {
   // Strip headings, bold/italic markers, links, and images
   let text = body.replace(/^#+\s.*$/gm, '');
@@ -197,23 +204,26 @@ export function extractDescription(body: string, maxLength = 160): string {
   text = text.replace(/\*{1,2}(.+?)\*{1,2}/g, '$1');
   text = text.replace(/_+(.+?)_+/g, '$1');
 
-  // Find the first non-empty paragraph
+  const truncate = (s: string) => {
+    if (s.length <= maxLength) return s;
+    const head = s.slice(0, maxLength - 1);
+    return `${head.slice(0, head.lastIndexOf(' '))}…`;
+  };
+
+  // Prefer the first paragraph that reads like prose (long enough and with
+  // sentence punctuation), so headings, labels, and date lines aren't used.
+  // Fall back to the first non-metadata paragraph so we never return empty.
+  let fallback = '';
   for (const paragraph of text.split('\n\n')) {
     const cleaned = paragraph.split(/\s+/).join(' ').trim();
-    const lowered = cleaned.toLowerCase();
-    if (lowered.startsWith('updated:') || lowered.startsWith('last updated:')) {
-      continue;
-    }
-    if (cleaned.length > 20) {
-      if (cleaned.length > maxLength) {
-        const truncated = cleaned.slice(0, maxLength - 1);
-        return `${truncated.slice(0, truncated.lastIndexOf(' '))}…`;
-      }
-      return cleaned;
+    if (cleaned.length <= 20 || METADATA_LEAD.test(cleaned)) continue;
+    if (!fallback) fallback = cleaned;
+    if (cleaned.length >= 60 && /[.!?]/.test(cleaned)) {
+      return truncate(cleaned);
     }
   }
 
-  return '';
+  return fallback ? truncate(fallback) : '';
 }
 
 export function loadInstruction(filename: string): string {

--- a/src/website/astro.config.mjs
+++ b/src/website/astro.config.mjs
@@ -5,7 +5,11 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   site: 'https://www.livingwhitepaper.com',
-  trailingSlash: 'always',
+  // 'ignore' (the default) — pages still emit as directory/index.html (trailing
+  // slash) and canonicals/sitemap use that form, but extension endpoints like
+  // /whitepaper/<series>.md resolve cleanly in dev too. 'always' wrongly forces
+  // a trailing slash onto those dynamic .md endpoints (404 in dev).
+  trailingSlash: 'ignore',
   integrations: [
     // Keep archived editions (…/whitepaper/<series>/<timestamp>/) out of the
     // sitemap — they're noindexed near-duplicates of the latest version.

--- a/src/website/public/robots.txt
+++ b/src/website/public/robots.txt
@@ -1,4 +1,36 @@
 User-agent: *
 Allow: /
 
+# This is an open, citable research project — AI and generative-engine
+# crawlers are explicitly welcome. Start here:
+#   Index (llms.txt standard): /llms.txt
+#   Full corpus:               /llms-full.txt
+#   Per-report markdown:       /whitepaper/<series>.md
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 Sitemap: https://www.livingwhitepaper.com/sitemap-index.xml

--- a/src/website/src/layouts/Base.astro
+++ b/src/website/src/layouts/Base.astro
@@ -10,11 +10,15 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import ogImage from '../assets/ainz.jpg';
 
+import { organizationNode, webSiteNode } from '../lib/seo';
+
 interface Props {
   title?: string;
   description?: string;
   /** Set on archived editions so search engines don't index near-duplicates. */
   noindex?: boolean;
+  /** Extra schema.org nodes (e.g. an Article) merged into the JSON-LD @graph. */
+  jsonLd?: Record<string, unknown>[];
 }
 
 const siteTitle = 'AI in NZ Living Whitepaper';
@@ -22,11 +26,21 @@ const {
   title,
   description = 'A living snapshot of the Generative AI landscape in Aotearoa New Zealand. Researching AI topics, using AI, for the AI community.',
   noindex = false,
+  jsonLd = [],
 } = Astro.props;
 
 const pageTitle = title ? `${title} · Living Whitepaper` : siteTitle;
 const canonical = new URL(Astro.url.pathname, Astro.site);
 const socialImage = new URL(ogImage.src, Astro.site);
+
+// Sitewide Organization + WebSite, plus any page-specific nodes. A single
+// @graph lets the Article node reference the org/website by @id.
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@graph': [organizationNode(Astro.site!), webSiteNode(Astro.site!), ...jsonLd],
+};
+// Escape `<` so a stray "</script>" in any string can't break out of the tag.
+const jsonLdHtml = JSON.stringify(structuredData).replace(/</g, '\\u003c');
 ---
 
 <!doctype html>
@@ -56,6 +70,7 @@ const socialImage = new URL(ogImage.src, Astro.site);
     <meta name="twitter:title" content={pageTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={socialImage} />
+    <script type="application/ld+json" is:inline set:html={jsonLdHtml} />
     <ClientRouter />
   </head>
   <body class="bg-paper text-ink font-serif antialiased">

--- a/src/website/src/lib/seo.ts
+++ b/src/website/src/lib/seo.ts
@@ -1,0 +1,64 @@
+/**
+ * schema.org JSON-LD helpers. The Organization and WebSite nodes are emitted
+ * sitewide (Base.astro); Article nodes reference them by @id so search engines
+ * and AI crawlers resolve a single connected entity graph.
+ */
+
+const ref = (site: URL, hash: string) => new URL(hash, site).href;
+
+export const ORG_ID = '/#org';
+export const WEBSITE_ID = '/#website';
+
+export const PUBLISHER_NAME =
+  'AI Forum New Zealand — Generative AI Working Group';
+
+export function organizationNode(site: URL): Record<string, unknown> {
+  return {
+    '@type': 'Organization',
+    '@id': ref(site, ORG_ID),
+    name: PUBLISHER_NAME,
+    url: 'https://aiforum.org.nz',
+    sameAs: ['https://github.com/mingnz/livingwp'],
+  };
+}
+
+export function webSiteNode(site: URL): Record<string, unknown> {
+  return {
+    '@type': 'WebSite',
+    '@id': ref(site, WEBSITE_ID),
+    name: 'AI in NZ Living Whitepaper',
+    url: new URL('/', site).href,
+    inLanguage: 'en-NZ',
+    publisher: { '@id': ref(site, ORG_ID) },
+  };
+}
+
+/** An Article node for a published report, referencing the sitewide org/website. */
+export function articleNode(
+  site: URL,
+  opts: {
+    url: URL;
+    headline: string;
+    description: string;
+    datePublished: Date;
+    dateModified: Date;
+    image: URL;
+  },
+): Record<string, unknown> {
+  return {
+    '@type': 'Article',
+    '@id': `${opts.url.href}#article`,
+    headline: opts.headline,
+    description: opts.description,
+    datePublished: opts.datePublished.toISOString(),
+    dateModified: opts.dateModified.toISOString(),
+    inLanguage: 'en-NZ',
+    isAccessibleForFree: true,
+    url: opts.url.href,
+    mainEntityOfPage: opts.url.href,
+    image: opts.image.href,
+    author: { '@id': ref(site, ORG_ID) },
+    publisher: { '@id': ref(site, ORG_ID) },
+    isPartOf: { '@id': ref(site, WEBSITE_ID) },
+  };
+}

--- a/src/website/src/pages/[...slug].astro
+++ b/src/website/src/pages/[...slug].astro
@@ -2,6 +2,8 @@
 import { render } from 'astro:content';
 import Base from '../layouts/Base.astro';
 import EditionTimeline from '../components/EditionTimeline.astro';
+import ogImage from '../assets/ainz.jpg';
+import { articleNode } from '../lib/seo';
 import {
   getAllArticles,
   getSeriesHistory,
@@ -28,17 +30,37 @@ const { entry } = Astro.props;
 const { Content } = await render(entry);
 const { data } = entry;
 
+const history = await getSeriesHistory(data.article_series);
 const latest = data.article_latest
   ? undefined
-  : (await getSeriesHistory(data.article_series)).find(
-      (e) => e.data.article_latest,
-    );
+  : history.find((e) => e.data.article_latest);
+
+const description = data.description ?? data.article_summary ?? '';
+const canonical = new URL(entry.data.permalink, Astro.site);
+// First edition in the series = original publication; this edition = modified.
+const firstPublished =
+  history[history.length - 1]?.data.article_updated_at ?? data.article_updated_at;
+
+const articleSchema = articleNode(Astro.site!, {
+  url: canonical,
+  headline: data.title,
+  description,
+  datePublished: firstPublished,
+  dateModified: data.article_updated_at,
+  image: new URL(ogImage.src, Astro.site),
+});
+
+// Clean-markdown view for AI crawlers / "copy as markdown" — latest editions only.
+const markdownUrl = data.article_latest
+  ? `/whitepaper/${data.article_series}.md`
+  : undefined;
 ---
 
 <Base
   title={data.title}
-  description={data.description ?? data.article_summary}
+  description={description}
   noindex={!data.article_latest}
+  jsonLd={[articleSchema]}
 >
   <div
     class="gap-12 py-10 sm:py-14 lg:grid lg:grid-cols-[minmax(0,1fr)_13rem] lg:gap-16"
@@ -93,12 +115,24 @@ const latest = data.article_latest
         <Content />
       </div>
 
-      <a
-        class="font-mono text-ink-muted hover:text-pounamu-deep mt-14 inline-block text-[0.72rem] tracking-[0.14em] uppercase underline decoration-rule underline-offset-4 transition-colors"
-        href="/whitepaper/"
-      >
-        ← Back to all articles
-      </a>
+      <div class="mt-14 flex flex-wrap items-center gap-x-7 gap-y-2">
+        <a
+          class="font-mono text-ink-muted hover:text-pounamu-deep inline-block text-[0.72rem] tracking-[0.14em] uppercase underline decoration-rule underline-offset-4 transition-colors"
+          href="/whitepaper/"
+        >
+          ← Back to all articles
+        </a>
+        {
+          markdownUrl && (
+            <a
+              class="font-mono text-ink-muted hover:text-pounamu-deep inline-block text-[0.72rem] tracking-[0.14em] uppercase underline decoration-rule underline-offset-4 transition-colors"
+              href={markdownUrl}
+            >
+              View as Markdown
+            </a>
+          )
+        }
+      </div>
     </article>
 
     <aside class="reveal reveal-2 border-rule mt-14 border-t pt-8 lg:mt-0 lg:border-t-0 lg:pt-0">

--- a/src/website/src/pages/llms-full.txt.ts
+++ b/src/website/src/pages/llms-full.txt.ts
@@ -1,0 +1,44 @@
+import type { APIRoute } from 'astro';
+import {
+  getLatestSnapshot,
+  getIndustryReports,
+  formatDate,
+  type Article,
+} from '../lib/articles';
+import { PUBLISHER_NAME } from '../lib/seo';
+
+// The full corpus in one fetch: the latest edition of every report,
+// concatenated. Lets an LLM ingest the whole site without crawling.
+export const GET: APIRoute = async ({ site }) => {
+  const abs = (p: string) => new URL(p, site!).href;
+  const snapshot = await getLatestSnapshot();
+  const reports = await getIndustryReports();
+  const entries: Article[] = [snapshot, ...reports].filter(
+    (e): e is Article => Boolean(e),
+  );
+
+  const parts: string[] = [
+    '# AI in NZ Living Whitepaper — full content',
+    '',
+    `> Latest edition of every report, researched and written by an AI agent, community-reviewed, published by ${PUBLISHER_NAME}.`,
+    `> Source: ${abs('/')} · Index: ${abs('/llms.txt')}`,
+    '',
+    '---',
+    '',
+  ];
+
+  for (const entry of entries) {
+    parts.push(
+      `> Source: ${abs(entry.data.permalink)} · Updated ${formatDate(entry.data.article_updated_at)}`,
+      '',
+      entry.body ?? '',
+      '',
+      '---',
+      '',
+    );
+  }
+
+  return new Response(parts.join('\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/src/website/src/pages/llms.txt.ts
+++ b/src/website/src/pages/llms.txt.ts
@@ -1,0 +1,59 @@
+import type { APIRoute } from 'astro';
+import {
+  getLatestSnapshot,
+  getIndustryReports,
+  formatDate,
+} from '../lib/articles';
+
+// https://llmstxt.org/ — a curated, link-first index for LLMs. Lists the
+// latest edition of each report with a one-line summary so a model can decide
+// what to fetch (the full text lives at /llms-full.txt and /whitepaper/<s>.md).
+export const GET: APIRoute = async ({ site }) => {
+  const abs = (p: string) => new URL(p, site!).href;
+  const snapshot = await getLatestSnapshot();
+  const reports = await getIndustryReports();
+
+  const summary = (a: { data: { article_summary?: string; description?: string } }) =>
+    a.data.article_summary ?? a.data.description ?? '';
+
+  const lines: string[] = [
+    '# AI in NZ Living Whitepaper',
+    '',
+    '> A living record of how generative AI is being adopted across industries in Aotearoa New Zealand. Each report is researched and written by an AI agent, reviewed by the community, and updated as the landscape evolves. Reports cite primary sources inline.',
+    '',
+  ];
+
+  if (snapshot) {
+    lines.push(
+      '## National snapshot',
+      '',
+      `- [${snapshot.data.title}](${abs(snapshot.data.permalink)}): ${summary(snapshot)} (updated ${formatDate(snapshot.data.article_updated_at)})`,
+      '',
+    );
+  }
+
+  lines.push('## Industry reports', '');
+  for (const r of reports) {
+    lines.push(
+      `- [${r.data.title}](${abs(r.data.permalink)}): ${summary(r)} (updated ${formatDate(r.data.article_updated_at)})`,
+    );
+  }
+
+  lines.push(
+    '',
+    '## Full content',
+    '',
+    `- [All reports concatenated](${abs('/llms-full.txt')})`,
+    '- Each report is also available as Markdown at `/whitepaper/<series>.md`',
+    '',
+    '## About',
+    '',
+    `- [How it works](${abs('/how-it-works/')}): how the AI agent researches and publishes each report`,
+    `- [About](${abs('/about/')}): the AI Forum NZ Generative AI Working Group`,
+    '',
+  );
+
+  return new Response(lines.join('\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/src/website/src/pages/whitepaper/[series].md.ts
+++ b/src/website/src/pages/whitepaper/[series].md.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from 'astro';
+import { getLatestArticles, formatDate } from '../../lib/articles';
+import { PUBLISHER_NAME } from '../../lib/seo';
+
+// Clean-markdown view of the latest edition of each report, for AI crawlers
+// and "copy as markdown" — e.g. /whitepaper/healthcare.md.
+export async function getStaticPaths() {
+  const latest = await getLatestArticles();
+  return latest.map((entry) => ({
+    params: { series: entry.data.article_series },
+    props: { entry },
+  }));
+}
+
+export const GET: APIRoute = ({ props, site }) => {
+  const { entry } = props;
+  const source = new URL(entry.data.permalink, site).href;
+  const header =
+    `> Source: ${source} · Updated ${formatDate(entry.data.article_updated_at)} · ${PUBLISHER_NAME}\n` +
+    '> Researched and written by an AI agent, reviewed by the community.\n\n';
+  return new Response(header + (entry.body ?? ''), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  });
+};


### PR DESCRIPTION
## Summary

A full SEO audit of the site plus GEO (generative-engine optimization) for AI crawlers. The content here is ideal for GEO — heavily cited, dated, structured AI-research reports — so this leans into making the site maximally legible to both search engines and LLMs. Targets `next`.

## Audit: what was already good (prior PRs)

Canonical URLs, sitemap (archives excluded), robots.txt, RSS, OG + Twitter cards, og:image, `noindex` on archives, semantic HTML/headings, descriptions. The two real gaps were **structured data** and **anything GEO-specific**.

## SEO additions

- **JSON-LD structured data** (`src/lib/seo.ts` + `Base.astro`): a sitewide `@graph` with `Organization` (the AI Forum NZ Generative AI Working Group) + `WebSite`, and an `Article` node on report pages, linked by `@id`. `Article.datePublished` = the series' first edition, `dateModified` = the current one; `author`/`publisher` resolve to the org. Validated: home page carries Organization+WebSite, report pages add Article with correct dates.
- **Better descriptions** (`extractDescription` in the agent): several reports had a title or date line as their meta description / OG / JSON-LD / llms.txt summary (e.g. AEC showed the title, Finance showed "Snapshot date: …"). The extractor now prefers real prose and skips metadata lead-lines. Verified all previously-weak reports now yield a proper sentence. (Stored frontmatter refreshes per report on the next agent run.)

## GEO additions

- **`/llms.txt`** — the [llmstxt.org](https://llmstxt.org) standard: a curated, link-first index of the latest edition of each report with one-line summaries and dates, so a model can decide what to fetch.
- **`/llms-full.txt`** — the entire corpus (latest edition of every report) concatenated into one file (~225 KB) for bulk ingestion without crawling.
- **`/whitepaper/<series>.md`** — a clean-markdown view of each latest report (raw article body + a source/attribution header), linked from each page as **"View as Markdown"**. 9 generated, one per series.
- **robots.txt** now explicitly welcomes AI crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, anthropic-ai, PerplexityBot, Google-Extended, Applebot-Extended, CCBot) and points them at the resources above — on-brand for an open, citable project that *wants* to be cited.

## Verification

- `npm run typecheck` (contract + agent + site `astro check`) — 0 errors
- `npm run build:site` — JSON-LD valid JSON on home (Organization, WebSite) and report pages (+ Article, correct datePublished/dateModified); `/llms.txt`, `/llms-full.txt`, and 9 `/whitepaper/<series>.md` emitted; robots.txt shipped; **HTML URL parity holds** (27 article pages); archives still excluded from sitemap.
- `extractDescription` improvement verified against the previously-weak reports.

## Notes

- The per-report `.md` and JSON-LD `image` reuse the existing optimized hero asset.
- Existing reports keep their current (weak, for some) stored summaries until the agent next regenerates them — only the *generator* is fixed here; no immutable content is hand-edited.